### PR TITLE
Host on Heroku and Fix the URL #3

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root to: redirect("https://web.kuru-anime.com/")
 end


### PR DESCRIPTION
# Story Title

[Host on Heroku and Fix the URL](https://github.com/kuru-project/main-website-server/issues/3)

# Changes made

- Add redirect for root on routes.rb

# How does the solution address the problem

This PR will redirect users going to the root path of api.kuru-anime.com to web.kuru-anime.com
