### PR TITLE
Redirect people going to api.kuru-anime.com to web.kuru-anime.com #56

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,11 @@ const cors = require('@koa/cors');
 const app = new Koa();
 const router = new Router();
 
+router.get('/', (ctx, next) => {
+  ctx.redirect('http://web.kuru-anime.com/');
+  ctx.status = 301;
+});
+
 router.get('/hello', (ctx, next) => {
   ctx.body = 'Hello World';
 });


### PR DESCRIPTION
# Story Title

[Redirect people going to api.kuru-anime.com to web.kuru-anime.com](https://github.com/kuru-project/main-website-server/issues/56)

# Changes made

- Add redirect for the `/` route

# How does the solution address the problem

This PR will add a redirect to the main route that goes to the Client side of Kuru Anime.

# Linked issues

Resolves #56 
